### PR TITLE
fix: Correctly update favicon in settings

### DIFF
--- a/kolder-app/src/App.jsx
+++ b/kolder-app/src/App.jsx
@@ -74,7 +74,7 @@ function App() {
   useEffect(() => {
     if (settings) {
       document.title = settings.title;
-      const favicon = document.getElementById('favicon');
+      const favicon = document.querySelector("link[rel*='icon']");
       if (favicon) {
         favicon.href = settings.icon;
       }


### PR DESCRIPTION
This commit fixes a bug where setting a new icon URL in the settings menu would not update the site's favicon. The JavaScript was previously looking for an element with `id="favicon"`, which did not exist.

The fix changes the DOM selection logic to use `document.querySelector("link[rel*='icon']")`, which is a more robust method for finding the favicon link element.