### PR TITLE
feat(search): Implement global snippet search

### DIFF
--- a/kolder-app/src/App.jsx
+++ b/kolder-app/src/App.jsx
@@ -174,12 +174,19 @@ function App() {
     }
   };
 
-  const filteredSnippets = snippets
-    .filter(snippet => snippet.categoryId === selectedCategory)
-    .filter(snippet =>
-      snippet.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      snippet.content.toLowerCase().includes(searchTerm.toLowerCase())
-    );
+  const handleSearchChange = (term) => {
+      setSearchTerm(term);
+      if(term) {
+          setSelectedCategory(null);
+      }
+  }
+
+  const filteredSnippets = searchTerm
+    ? snippets.filter(snippet =>
+        snippet.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        snippet.content.toLowerCase().includes(searchTerm.toLowerCase())
+      )
+    : snippets.filter(snippet => snippet.categoryId === selectedCategory);
 
   if (loading) {
     return (
@@ -229,9 +236,9 @@ function App() {
             ) : (
                 <SnippetList
                 snippets={filteredSnippets}
-                selectedCategory={selectedCategory}
+              categories={categories}
                 searchTerm={searchTerm}
-                onSearchChange={setSearchTerm}
+              onSearchChange={handleSearchChange}
                 onAdd={handleAddSnippet}
                 onEdit={handleEditSnippet}
                 onDelete={handleDeleteSnippet}

--- a/kolder-app/src/components/SnippetList.jsx
+++ b/kolder-app/src/components/SnippetList.jsx
@@ -12,7 +12,21 @@ import {
 import { AddIcon, DeleteIcon, EditIcon } from '@chakra-ui/icons';
 import SnippetEditor from './SnippetEditor';
 
-const SnippetList = ({ snippets, selectedCategory, searchTerm, onSearchChange, onAdd, onEdit, onDelete, onSelectSnippet }) => {
+const getCategoryPath = (id, categories, path = []) => {
+    for (const category of categories) {
+        const newPath = [...path, category.name];
+        if (category.id === id) {
+            return newPath.join(' / ');
+        }
+        if (category.children && category.children.length > 0) {
+            const foundPath = getCategoryPath(id, category.children, newPath);
+            if (foundPath) return foundPath;
+        }
+    }
+    return null;
+};
+
+const SnippetList = ({ snippets, categories, searchTerm, onSearchChange, onAdd, onEdit, onDelete, onSelectSnippet }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [editingSnippet, setEditingSnippet] = useState(null);
 
@@ -34,35 +48,40 @@ const SnippetList = ({ snippets, selectedCategory, searchTerm, onSearchChange, o
     }
   };
 
-  if (!selectedCategory) {
-    return (
-      <Box>
-        <Heading size="md">Snippets</Heading>
-        <Text mt="4">Select a category to see its snippets.</Text>
-      </Box>
-    );
-  }
+  const isSearching = searchTerm !== '';
 
   return (
     <Box>
       <Flex align="center" mb="4">
-        <Heading size="md">Snippets</Heading>
-        <Button size="sm" ml="auto" leftIcon={<AddIcon />} onClick={handleNew}>
+        <Heading size="md">{isSearching ? `Search Results for "${searchTerm}"` : 'Snippets'}</Heading>
+        <Button size="sm" ml="auto" leftIcon={<AddIcon />} onClick={handleNew} disabled={isSearching}>
           New Snippet
         </Button>
       </Flex>
       <Input
-        placeholder="Search snippets..."
+        placeholder="Search all snippets..."
         value={searchTerm}
         onChange={(e) => onSearchChange(e.target.value)}
         mb={4}
       />
       {snippets.length === 0 ? (
-        <Text>No snippets match your search.</Text>
+        <Text>
+            {isSearching
+                ? 'No snippets match your search.'
+                : 'No snippets in this category. Select a category or use the search bar.'
+            }
+        </Text>
       ) : (
         snippets.map((snippet) => (
-          <Flex key={snippet.id} align="center" justify="space-between" p="2" borderWidth="1px" borderRadius="md" mt="2">
-            <Text cursor="pointer" onClick={() => onSelectSnippet(snippet)}>{snippet.name}</Text>
+          <Flex key={snippet.id} align="center" justify="space-between" p={3} borderWidth="1px" borderRadius="md" mt={2}>
+            <Box>
+                <Text fontWeight="bold" cursor="pointer" onClick={() => onSelectSnippet(snippet)}>{snippet.name}</Text>
+                {isSearching && (
+                    <Text fontSize="xs" color="gray.500">
+                        in: {getCategoryPath(snippet.categoryId, categories)}
+                    </Text>
+                )}
+            </Box>
             <Box>
               <IconButton size="sm" icon={<EditIcon />} mr="2" onClick={() => handleEdit(snippet)} />
               <IconButton size="sm" icon={<DeleteIcon />} onClick={() => onDelete(snippet.id)} />

--- a/kolder-app/src/index.css
+++ b/kolder-app/src/index.css
@@ -3,66 +3,17 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+#root {
+    width: 100%;
+    min-height: 100vh;
 }


### PR DESCRIPTION
This commit refactors the search functionality to be global instead of category-specific, based on user feedback.

Changes:
- The search bar now searches across all snippets in all categories.
- When a search is active, the category selection is cleared to indicate a global search context.
- Search results now display the full category path for each snippet (e.g., "Work / Emails") to provide context.
- The "New Snippet" button is disabled during a search, as a category must be selected to create a new snippet.