### PR TITLE
fix: Use relative API path to resolve deployment crash

### DIFF
--- a/kolder-app/src/App.jsx
+++ b/kolder-app/src/App.jsx
@@ -20,7 +20,7 @@ import SettingsModal from './components/SettingsModal';
 import AnalyticsPage from './components/AnalyticsPage';
 
 const api = axios.create({
-  baseURL: 'http://localhost:3001/api',
+  baseURL: '/api',
 });
 
 function App() {

--- a/kolder-app/vite.config.js
+++ b/kolder-app/vite.config.js
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
+// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    }
+  }
 })


### PR DESCRIPTION
This commit fixes a critical deployment bug that resulted in a "white screen" crash.

The root cause was a hardcoded `baseURL` ('http://localhost:3001/api') for API calls in the frontend. This failed in a containerized deployment environment where `localhost` does not resolve to the backend server.

The fix involves:
- Changing the `axios` `baseURL` in `App.jsx` to a relative path (`/api`). This allows the browser to correctly resolve the API endpoint relative to the domain from which the app is served.
- Adding a `vite.config.js` proxy configuration to redirect `/api` requests to `http://localhost:3001` during local development, ensuring the two-server development environment remains functional.