### PR TITLE
feat(ui): Increase sidebar width to 300px

### DIFF
--- a/kolder-app/src/App.jsx
+++ b/kolder-app/src/App.jsx
@@ -196,7 +196,7 @@ function App() {
         <AnalyticsPage onBack={() => setCurrentView('main')} snippets={snippets} setSnippets={setSnippets} settings={settings}/>
       ) : (
         <Flex flex="1">
-            <Box as="aside" w="250px" p="4" borderRightWidth="1px" bg={settings?.theme.contentBackgroundColor} borderColor={settings?.theme.contentBackgroundColor}>
+            <Box as="aside" w="300px" p="4" borderRightWidth="1px" bg={settings?.theme.contentBackgroundColor} borderColor={settings?.theme.contentBackgroundColor} overflowX="auto">
             <CategoryTree
                 settings={settings}
                 categories={categories}


### PR DESCRIPTION
Based on user feedback, this commit increases the width of the category sidebar from 250px to 300px. This provides more space for nested category names and improves the overall layout balance.