### PR TITLE
fix: Relocate 'Starting Snippets' feature to viewer

### DIFF
--- a/kolder-app/src/components/SnippetEditor.jsx
+++ b/kolder-app/src/components/SnippetEditor.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -11,34 +11,16 @@ import {
   FormLabel,
   Input,
   Button,
-  Select,
   VStack,
 } from '@chakra-ui/react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
-import './quill.css'; // Import custom Quill styles
-import axios from 'axios';
-
-const api = axios.create({
-    baseURL: '/api',
-});
+import './quill.css';
 
 const SnippetEditor = ({ isOpen, onClose, onSave, snippet, settings }) => {
   const [name, setName] = useState('');
   const [content, setContent] = useState('');
-  const [startingSnippets, setStartingSnippets] = useState([]);
-  const quillRef = useRef(null); // Ref to access Quill editor instance
 
-  // Fetch starting snippets when modal opens
-  useEffect(() => {
-    if (isOpen) {
-        api.get('/starting-snippets')
-           .then(response => setStartingSnippets(response.data))
-           .catch(error => console.error('Error fetching starting snippets', error));
-    }
-  }, [isOpen]);
-
-  // Populate editor when snippet is being edited
   useEffect(() => {
     if (isOpen) {
         if (snippet) {
@@ -56,21 +38,6 @@ const SnippetEditor = ({ isOpen, onClose, onSave, snippet, settings }) => {
     onClose();
   };
 
-  const handleStartingSnippetChange = (e) => {
-    const snippetId = e.target.value;
-    const selected = startingSnippets.find(ss => ss._id === snippetId);
-    if (selected) {
-        // Prepend the content
-        const newContent = selected.content + '<p><br></p>' + content;
-        setContent(newContent);
-
-        // Focus the editor
-        if (quillRef.current) {
-            quillRef.current.getEditor().focus();
-        }
-    }
-  };
-
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl">
       <ModalOverlay />
@@ -78,23 +45,15 @@ const SnippetEditor = ({ isOpen, onClose, onSave, snippet, settings }) => {
         <ModalHeader>{snippet ? 'Edit Snippet' : 'New Snippet'}</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-            <VStack spacing={4} align="stretch">
-                <FormControl>
-                    <FormLabel>Name</FormLabel>
-                    <Input value={name} onChange={(e) => setName(e.target.value)} />
-                </FormControl>
-                <FormControl>
-                    <FormLabel>Insert Starting Snippet</FormLabel>
-                    <Select placeholder="Select a starting snippet..." onChange={handleStartingSnippetChange}>
-                        {startingSnippets.map(ss => (
-                            <option key={ss._id} value={ss._id}>{ss.name}</option>
-                        ))}
-                    </Select>
-                </FormControl>
-                <FormControl>
-                    <FormLabel>Content</FormLabel>
-                    <ReactQuill ref={quillRef} theme="snow" value={content} onChange={setContent} />
-                </FormControl>
+          <VStack spacing={4} align="stretch">
+            <FormControl>
+                <FormLabel>Name</FormLabel>
+                <Input value={name} onChange={(e) => setName(e.target.value)} />
+            </FormControl>
+            <FormControl>
+                <FormLabel>Content</FormLabel>
+                <ReactQuill theme="snow" value={content} onChange={setContent} />
+            </FormControl>
           </VStack>
         </ModalBody>
         <ModalFooter>

--- a/kolder-app/src/components/SnippetViewer.jsx
+++ b/kolder-app/src/components/SnippetViewer.jsx
@@ -9,6 +9,7 @@ import {
   Input,
   Text,
   VStack,
+  Select,
 } from '@chakra-ui/react';
 import { ArrowBackIcon } from '@chakra-ui/icons';
 import axios from 'axios';
@@ -21,24 +22,17 @@ const SnippetViewer = ({ snippet, onBack, settings }) => {
   const [placeholders, setPlaceholders] = useState({});
   const [output, setOutput] = useState('');
   const [hasCopied, setHasCopied] = useState(false);
+  const [startingSnippets, setStartingSnippets] = useState([]);
+  const [prefix, setPrefix] = useState('');
 
-  const handleCopy = () => {
-    // 1. Create a temporary element to parse the HTML
-    const tempDiv = document.createElement('div');
-    tempDiv.innerHTML = output;
-    // 2. Get the plain text content
-    const plainText = tempDiv.textContent || tempDiv.innerText || '';
+  // Fetch starting snippets
+  useEffect(() => {
+    api.get('/starting-snippets')
+       .then(response => setStartingSnippets(response.data))
+       .catch(error => console.error('Error fetching starting snippets', error));
+  }, []);
 
-    // 3. Use the Clipboard API to copy the plain text
-    navigator.clipboard.writeText(plainText).then(() => {
-        setHasCopied(true);
-        setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
-    });
-
-    // 4. Track the usage via API
-    api.post(`/snippets/${snippet._id}/track`).catch(err => console.error("Failed to track copy", err));
-  }
-
+  // Set placeholders when snippet changes
   useEffect(() => {
     if (!snippet.content) return;
     const placeholderRegex = /{{(.*?)}}/g;
@@ -48,18 +42,43 @@ const SnippetViewer = ({ snippet, onBack, settings }) => {
         initialPlaceholders[match[1]] = '';
     });
     setPlaceholders(initialPlaceholders);
+    setPrefix(''); // Reset prefix when snippet changes
   }, [snippet]);
 
+  // Update the final output when prefix or placeholders change
   useEffect(() => {
-    let newOutput = snippet.content || '';
+    let snippetWithPlaceholders = snippet.content || '';
     for (const key in placeholders) {
-      newOutput = newOutput.replace(new RegExp(`{{${key}}}`, 'g'), placeholders[key]);
+      snippetWithPlaceholders = snippetWithPlaceholders.replace(new RegExp(`{{${key}}}`, 'g'), placeholders[key]);
     }
-    setOutput(newOutput);
-  }, [placeholders, snippet]);
+    setOutput(prefix + snippetWithPlaceholders);
+  }, [prefix, placeholders, snippet]);
+
+  const handleCopy = () => {
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = output;
+    const plainText = tempDiv.textContent || tempDiv.innerText || '';
+    navigator.clipboard.writeText(plainText).then(() => {
+        setHasCopied(true);
+        setTimeout(() => setHasCopied(false), 2000);
+    });
+    api.post(`/snippets/${snippet._id}/track`).catch(err => console.error("Failed to track copy", err));
+  }
 
   const handlePlaceholderChange = (key, value) => {
     setPlaceholders(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleStartingSnippetChange = (e) => {
+    const snippetId = e.target.value;
+    if (!snippetId) {
+        setPrefix('');
+        return;
+    }
+    const selected = startingSnippets.find(ss => ss._id === snippetId);
+    if (selected) {
+        setPrefix(selected.content + '<p><br></p>');
+    }
   };
 
   return (
@@ -73,19 +92,29 @@ const SnippetViewer = ({ snippet, onBack, settings }) => {
 
       <VStack spacing="4" align="stretch">
         <Box bg={settings?.theme.contentBackgroundColor} p={4} borderRadius="md">
-          <Heading size="sm" mb="2">Fill Placeholders</Heading>
-          {Object.keys(placeholders).length > 0 ? (
-            Object.keys(placeholders).map(key => (
-              <FormControl key={key} mt="2">
-                <FormLabel>{key}</FormLabel>
-                <Input
-                  value={placeholders[key]}
-                  onChange={(e) => handlePlaceholderChange(key, e.target.value)}
-                />
-              </FormControl>
-            ))
-          ) : (
-            <Text>No placeholders in this snippet.</Text>
+          <Heading size="sm" mb="2">Compose Snippet</Heading>
+          <FormControl>
+            <FormLabel>Add Starting Snippet</FormLabel>
+            <Select placeholder="None" onChange={handleStartingSnippetChange}>
+                {startingSnippets.map(ss => (
+                    <option key={ss._id} value={ss._id}>{ss.name}</option>
+                ))}
+            </Select>
+          </FormControl>
+
+          {Object.keys(placeholders).length > 0 && (
+            <Box mt={4}>
+                <Heading size="sm" mb="2">Fill Placeholders</Heading>
+                {Object.keys(placeholders).map(key => (
+                <FormControl key={key} mt="2">
+                    <FormLabel>{key}</FormLabel>
+                    <Input
+                    value={placeholders[key]}
+                    onChange={(e) => handlePlaceholderChange(key, e.target.value)}
+                    />
+                </FormControl>
+                ))}
+            </Box>
           )}
         </Box>
 
@@ -95,6 +124,7 @@ const SnippetViewer = ({ snippet, onBack, settings }) => {
             p="4"
             borderWidth="1px"
             borderRadius="md"
+            minHeight="150px"
             bg={settings?.theme.contentBackgroundColor}
             borderColor={settings?.theme.accentColor}
             dangerouslySetInnerHTML={{ __html: output }}


### PR DESCRIPTION
This commit corrects the implementation of the 'Starting Snippets' feature based on user clarification.

The feature was incorrectly implemented in the `SnippetEditor` component. It has now been moved to the `SnippetViewer` component, which is the correct place for composing the final output text.

Changes:
- The dropdown menu for selecting a starting snippet has been removed from the editor modal.
- The dropdown menu has been added to the viewer page, where placeholders are filled.
- Selecting a starting snippet now prepends its content to the live preview and the final copied text.