### PR TITLE
Fix: Prevent search input from losing focus

### DIFF
--- a/kolder-app/src/components/SnippetList.jsx
+++ b/kolder-app/src/components/SnippetList.jsx
@@ -29,12 +29,6 @@ const getCategoryPath = (id, categories, path = []) => {
 const SnippetList = ({ snippets, categories, searchTerm, onSearchChange, onAdd, onEdit, onDelete, onSelectSnippet, settings }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [editingSnippet, setEditingSnippet] = useState(null);
-  const [localSearchTerm, setLocalSearchTerm] = useState(searchTerm);
-
-  useEffect(() => {
-    // Sync local state if the external searchTerm changes (e.g., cleared)
-    setLocalSearchTerm(searchTerm);
-  }, [searchTerm]);
 
   const handleNew = () => {
     setEditingSnippet(null);
@@ -53,11 +47,6 @@ const SnippetList = ({ snippets, categories, searchTerm, onSearchChange, onAdd, 
       onAdd(snippet);
     }
   };
-
-  const handleSearchInputChange = (e) => {
-    setLocalSearchTerm(e.target.value);
-    onSearchChange(e.target.value);
-  }
 
   const isSearching = searchTerm !== '';
 
@@ -81,8 +70,8 @@ const SnippetList = ({ snippets, categories, searchTerm, onSearchChange, onAdd, 
       </Flex>
       <Input
         placeholder="Search all snippets..."
-        value={localSearchTerm}
-        onChange={handleSearchInputChange}
+        value={searchTerm}
+        onChange={(e) => onSearchChange(e.target.value)}
         mb={4}
       />
       {snippets.length === 0 ? (


### PR DESCRIPTION
The snippet search input was losing focus on every keystroke. This was caused by redundant local state within the `SnippetList` component, which triggered unnecessary re-renders and caused the input to lose focus.

This fix removes the local state (`localSearchTerm`) from the `SnippetList` component and instead uses the `searchTerm` prop directly from the parent `App` component. This simplifies the data flow, makes `App` the single source of truth for the search term, and resolves the focus issue.