### PR TITLE
Feat: Implement named date placeholders and update date format

### DIFF
--- a/kolder-app/src/components/SnippetEditor.jsx
+++ b/kolder-app/src/components/SnippetEditor.jsx
@@ -54,21 +54,15 @@ const SnippetEditor = ({ isOpen, onClose, onSave, snippet, settings }) => {
   };
 
   const handleInsertDatePlaceholder = () => {
+    const name = prompt('Enter a name for the date variable (e.g., invoice_date):');
+    if (!name || name.trim() === '') {
+        return; // User cancelled or entered empty name
+    }
+    const sanitizedName = name.trim().replace(/\s+/g, '_'); // Replace spaces with underscores
+
     const editor = quillRef.current.getEditor();
     const range = editor.getSelection(true);
-
-    // Get the current content directly from the editor to avoid stale state
-    const currentContent = editor.getText();
-    const existingDates = currentContent.match(/{{date_(\d+)}}/g) || [];
-    let nextId = 1;
-    if (existingDates.length > 0) {
-      const highestId = existingDates
-        .map(p => parseInt(p.match(/(\d+)/)[0], 10))
-        .reduce((max, id) => Math.max(max, id), 0);
-      nextId = highestId + 1;
-    }
-
-    const variableName = `{{date_${nextId}}}`;
+    const variableName = `{{date:${sanitizedName}}}`;
     editor.insertText(range.index, variableName);
   };
 

--- a/kolder-app/src/components/SnippetViewer.jsx
+++ b/kolder-app/src/components/SnippetViewer.jsx
@@ -24,18 +24,19 @@ const api = axios.create({
 
 // A new sub-component to manage the date variables UI in the viewer
 const DateManager = ({ content, dateValues, onDateChange }) => {
-    const expressionRegex = /{{\s*date_(\d+)(?:\s*[+-]\s*\d+\s*[dwmy])?\s*}}/g;
-    const baseVarRegex = /date_(\d+)/;
+    const placeholderRegex = /{{\s*([^}]+)\s*}}/g;
+    const dateVarRegex = /^date:(\w+)/; // Matches "date:name" at the start of an expression
 
-    const found = content.matchAll(expressionRegex);
+    const found = content.matchAll(placeholderRegex);
     const baseVars = new Set();
     for (const match of found) {
-        const baseVarMatch = match[0].match(baseVarRegex);
-        if (baseVarMatch) {
-            baseVars.add(baseVarMatch[0]);
+        const expression = match[1]; // e.g., "date:invoice_date + 5d"
+        const dateVarMatch = expression.match(dateVarRegex);
+        if (dateVarMatch) {
+            // dateVarMatch[1] will be "invoice_date"
+            baseVars.add(dateVarMatch[1]);
         }
     }
-
     const uniqueBaseVars = [...baseVars];
 
     if (uniqueBaseVars.length === 0) {
@@ -52,7 +53,7 @@ const DateManager = ({ content, dateValues, onDateChange }) => {
                         selected={dateValues[varName] ? new Date(dateValues[varName]) : null}
                         onChange={date => onDateChange(varName, date)}
                         customInput={<Input />}
-                        dateFormat="yyyy-MM-dd"
+                        dateFormat="dd.MM.yyyy"
                         isClearable
                     />
                 </FormControl>
@@ -80,8 +81,8 @@ const SnippetViewer = ({ snippet, onBack, settings }) => {
   useEffect(() => {
     if (!snippet.content) return;
 
-    // This regex now finds simple {{placeholders}} but ignores the {{date_...}} ones
-    const placeholderRegex = /{{\s*(?!date_)([^}]+)\s*}}/g;
+    // This regex now finds simple {{placeholders}} but ignores the {{date:...}} ones
+    const placeholderRegex = /{{\s*(?!date:)([^}]+)\s*}}/g;
     const foundPlaceholders = [...snippet.content.matchAll(placeholderRegex)];
     const initialPlaceholders = {};
 

--- a/kolder-app/src/utils/placeholder-evaluator.js
+++ b/kolder-app/src/utils/placeholder-evaluator.js
@@ -2,8 +2,8 @@ import { add, sub, format } from 'date-fns';
 
 const placeholderRegex = /{{\s*([^}]+)\s*}}/g;
 // Regex to parse: variable, operator, amount, unit
-// e.g., "date_1 + 10 d"
-const expressionRegex = /^(\w+)(?:\s*([+-])\s*(\d+)\s*([dwmy]))?$/;
+// e.g., "date:invoice_date + 10 d"
+const expressionRegex = /^date:(\w+)(?:\s*([+-])\s*(\d+)\s*([dwmy]))?$/;
 
 export const evaluatePlaceholders = (text, dateValues) => {
   if (!text || !dateValues) {
@@ -46,8 +46,8 @@ export const evaluatePlaceholders = (text, dateValues) => {
         }
       }
 
-      // Using format for consistent output, e.g., "2025-08-26"
-      return format(baseDate, 'yyyy-MM-dd');
+      // Using format for consistent output, e.g., "25.08.2025"
+      return format(baseDate, 'dd.MM.yyyy');
 
     } catch (error) {
       console.error("Error evaluating placeholder:", error);


### PR DESCRIPTION
This commit introduces two related improvements to the date placeholder feature:
1.  **Named Date Placeholders:** The previous `{{date_1}}` syntax has been replaced with a more descriptive `{{date:name}}` syntax (e.g., `{{date:invoice_date}}`). The snippet editor now prompts for a name when inserting a date placeholder. The snippet viewer then dynamically creates a labeled `DatePicker` for each unique name, improving usability for complex snippets.
2.  **Date Format:** The date format used for both the `DatePicker` input and the final evaluated output has been changed from `yyyy-MM-dd` to `dd.MM.yyyy` as requested.

This involved updating the placeholder handling logic in the snippet editor, the viewer's `DateManager` component, and the core `placeholder-evaluator` utility to support the new syntax and format.