### PR TITLE
Feat: Implement draggable categories

### DIFF
--- a/kolder-app/package-lock.json
+++ b/kolder-app/package-lock.json
@@ -19,6 +19,8 @@
         "i18next-http-backend": "^3.0.2",
         "react": "^18.2.0",
         "react-datepicker": "^8.7.0",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
         "react-i18next": "^15.7.2",
         "react-icons": "^5.5.0",
@@ -1217,6 +1219,24 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2391,6 +2411,17 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2904,7 +2935,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -4725,6 +4755,45 @@
         "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -4900,6 +4969,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/kolder-app/package.json
+++ b/kolder-app/package.json
@@ -24,7 +24,9 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^15.7.2",
     "react-icons": "^5.5.0",
-    "react-quill": "^2.0.0"
+    "react-quill": "^2.0.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/kolder-app/src/App.jsx
+++ b/kolder-app/src/App.jsx
@@ -12,6 +12,8 @@ import {
   Image,
 } from '@chakra-ui/react';
 import { SettingsIcon, ViewIcon, AddIcon } from '@chakra-ui/icons';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 import CategoryTree from './components/CategoryTree';
 import SnippetList from './components/SnippetList';
 import SnippetViewer from './components/SnippetViewer';
@@ -44,6 +46,7 @@ const MainView = ({
     onEditSnippet,
     onDeleteSnippet,
     onSelectSnippet,
+    onMoveCategory,
 }) => (
     <Flex flex="1">
         <Box as="aside" w="300px" p="4" borderRightWidth="1px" bg={settings?.theme.contentBackgroundColor} borderColor={settings?.theme.contentBackgroundColor} overflowX="auto">
@@ -57,6 +60,7 @@ const MainView = ({
                 selectedCategory={selectedCategory}
                 openCategories={openCategories}
                 onToggleCategory={onToggleCategory}
+                onMove={onMoveCategory}
             />
         </Box>
         <Box as="main" flex="1" p="4">
@@ -182,6 +186,15 @@ function App() {
     }
   };
 
+  const handleMoveCategory = async (draggedId, targetId) => {
+    try {
+        await api.put(`/categories/${draggedId}`, { parentId: targetId });
+        await fetchAllData();
+    } catch (error) {
+        console.error('Error moving category:', error);
+    }
+  };
+
   const handleSelectCategory = (id) => {
     setSelectedCategory(id);
     setSearchTerm('');
@@ -258,6 +271,7 @@ function App() {
                   onEditSnippet={handleEditSnippet}
                   onDeleteSnippet={handleDeleteSnippet}
                   onSelectSnippet={handleSelectSnippet}
+                  onMoveCategory={handleMoveCategory}
               />;
       }
   }
@@ -271,9 +285,10 @@ function App() {
   }
 
   return (
-    <Flex direction="column" minH="100vh" w="100%" bg={settings?.theme.backgroundColor} color={settings?.theme.textColor}>
-      <Flex as="header" p="4" borderBottomWidth="1px" alignItems="center" borderColor={settings?.theme.contentBackgroundColor}>
-        {settings?.icon && <Image src={settings.icon} alt="App Icon" boxSize="32px" mr={3} />}
+    <DndProvider backend={HTML5Backend}>
+      <Flex direction="column" minH="100vh" w="100%" bg={settings?.theme.backgroundColor} color={settings?.theme.textColor}>
+        <Flex as="header" p="4" borderBottomWidth="1px" alignItems="center" borderColor={settings?.theme.contentBackgroundColor}>
+          {settings?.icon && <Image src={settings.icon} alt="App Icon" boxSize="32px" mr={3} />}
         <Heading size="md">{settings?.title || 'Kolder'}</Heading>
         <Spacer />
         <IconButton
@@ -317,6 +332,7 @@ function App() {
         settings={settings}
       />
     </Flex>
+    </DndProvider>
   );
 }
 


### PR DESCRIPTION
This commit introduces the ability to reorganize categories using drag-and-drop. Users can now move categories to re-parent them under other categories or move them to the top level.

This was implemented by:
1.  Adding `react-dnd` and `react-dnd-html5-backend` as dependencies.
2.  Updating the `PUT /api/categories/:id` backend endpoint to support changing a category's `parentId`, including a check to prevent circular dependencies.
3.  Refactoring the `CategoryTree.jsx` component to use `react-dnd`'s `useDrag` and `useDrop` hooks, enabling the drag-and-drop functionality.
4.  Adding a `RootDropZone` component to allow moving categories to the top level.
5.  Wrapping the application in `DndProvider` and adding the necessary state management in `App.jsx` to handle the move operations.