### PR TITLE
Fix: Correct category drop target scope

### DIFF
--- a/kolder-app/src/components/CategoryTree.jsx
+++ b/kolder-app/src/components/CategoryTree.jsx
@@ -62,8 +62,8 @@ const DraggableCategory = ({ category, onAdd, onEdit, onDelete, onSelectCategory
   const isSelected = selectedCategory === category._id;
 
   return (
-    <Box pl="4" mt="2" ref={ref} style={{ opacity: isDragging ? 0.5 : 1 }}>
-      <Flex align="center" bg={isOver && canDrop ? 'green.100' : 'transparent'} borderRadius="md">
+    <Box pl="4" mt="2" style={{ opacity: isDragging ? 0.5 : 1 }}>
+      <Flex align="center" ref={ref} bg={isOver && canDrop ? 'green.100' : 'transparent'} borderRadius="md">
         <IconButton
           size="xs"
           mr="2"


### PR DESCRIPTION
This commit fixes a bug where dropping a snippet or another category onto a subcategory would incorrectly assign it to the subcategory's parent.

The issue was caused by the drop target ref in the `DraggableCategory` component being placed on an outer `Box` element that wrapped both the category's title and its children's collapsible section. This caused the parent's drop zone to overlap with its children's, leading to incorrect drop handling.

The fix moves the `ref` from the outer `Box` to the inner `Flex` element that contains only the category's title bar. This correctly scopes each category's drop zone, ensuring that drop events are handled by the correct, most deeply nested target.