### PR TITLE
Fix: Resolve application crash by correcting import order

### DIFF
--- a/kolder-app/src/components/SnippetViewer.jsx
+++ b/kolder-app/src/components/SnippetViewer.jsx
@@ -18,14 +18,13 @@ import {
 import { ArrowBackIcon } from '@chakra-ui/icons';
 import axios from 'axios';
 import DatePicker from 'react-datepicker';
+import { parsePlaceholders } from '../utils/placeholder-parser';
 import 'react-datepicker/dist/react-datepicker.css';
 import './quill.css'; // For consistent styling if needed
 
 const api = axios.create({
     baseURL: '/api',
 });
-
-import { parsePlaceholders } from '../utils/placeholder-parser';
 
 // A new sub-component to manage the date variables UI in the viewer
 const DateManager = ({ dateVars, dateValues, onDateChange }) => {


### PR DESCRIPTION
This commit fixes a critical bug that caused the application to show a white screen on load.

The issue was a JavaScript syntax error in `SnippetViewer.jsx`, where an `import` statement was incorrectly placed in the middle of the file after other code had been executed. All ES module `import` statements must be at the top level of the module.

The fix moves the misplaced import statement to the top of the file, resolving the syntax error and allowing the application to load correctly.