### PR TITLE
Feat: Implement placeholder builder UI and logic

### DIFF
--- a/kolder-app/src/components/PlaceholderBuilderModal.jsx
+++ b/kolder-app/src/components/PlaceholderBuilderModal.jsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -8,16 +9,140 @@ import {
   ModalCloseButton,
   Button,
   VStack,
+  FormControl,
+  FormLabel,
+  Select,
+  Input,
+  RadioGroup,
+  Radio,
+  HStack,
+  IconButton,
 } from '@chakra-ui/react';
+import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
 
 const PlaceholderBuilderModal = ({ isOpen, onClose, onInsert }) => {
-  // Logic for building placeholders will go here
+  const [type, setType] = useState('text'); // 'text', 'date', 'choice'
+  const [name, setName] = useState('');
+  const [options, setOptions] = useState(['']);
+  const [displayType, setDisplayType] = useState('dropdown');
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setType('text');
+      setName('');
+      setOptions(['']);
+      setDisplayType('dropdown');
+    }
+  }, [isOpen]);
 
   const handleInsert = () => {
-    // This will eventually build the placeholder string
-    const placeholderString = '{{test_from_modal}}';
+    if (!name.trim()) {
+        // Basic validation
+        alert('Placeholder Name is required.');
+        return;
+    }
+
+    let placeholderString = '';
+    const sanitizedName = name.trim().replace(/\s+/g, '_');
+
+    switch (type) {
+        case 'text':
+            placeholderString = `{{${sanitizedName}}}`;
+            break;
+        case 'date':
+            placeholderString = `{{date:${sanitizedName}}}`;
+            break;
+        case 'choice': {
+            const validOptions = options.map(o => o.trim()).filter(o => o);
+            if (validOptions.length === 0) {
+                alert('At least one option is required for a choice placeholder.');
+                return;
+            }
+            placeholderString = `{{select:${sanitizedName}:${displayType}:${validOptions.join(':')}}}`;
+            break;
+        }
+        default:
+            return; // Should not happen
+    }
+
     onInsert(placeholderString);
     onClose();
+  };
+
+  const renderConfigUI = () => {
+    switch (type) {
+      case 'text':
+      case 'date':
+        return (
+          <FormControl isRequired>
+            <FormLabel>Placeholder Name</FormLabel>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={type === 'date' ? 'e.g., invoice_date' : 'e.g., customer_name'}
+            />
+          </FormControl>
+        );
+      case 'choice':
+        return (
+            <>
+                <FormControl isRequired>
+                    <FormLabel>Placeholder Name</FormLabel>
+                    <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g., salutation" />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Display Style</FormLabel>
+                    <RadioGroup onChange={setDisplayType} value={displayType}>
+                        <HStack>
+                            <Radio value="dropdown">Dropdown</Radio>
+                            <Radio value="radio">Radio Buttons</Radio>
+                        </HStack>
+                    </RadioGroup>
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Options</FormLabel>
+                    <VStack align="stretch">
+                        {options.map((option, index) => (
+                            <HStack key={index}>
+                                <Input
+                                    value={option}
+                                    onChange={(e) => handleOptionChange(index, e.target.value)}
+                                    placeholder={`Option ${index + 1}`}
+                                />
+                                <IconButton
+                                    icon={<DeleteIcon />}
+                                    onClick={() => removeOption(index)}
+                                    aria-label="Remove option"
+                                    isDisabled={options.length <= 1}
+                                />
+                            </HStack>
+                        ))}
+                    </VStack>
+                    <Button size="sm" mt={2} leftIcon={<AddIcon />} onClick={addOption}>Add Option</Button>
+                </FormControl>
+            </>
+        )
+      default:
+        return null;
+    }
+  };
+
+  const handleOptionChange = (index, value) => {
+    const newOptions = [...options];
+    newOptions[index] = value;
+    setOptions(newOptions);
+  };
+
+  const addOption = () => {
+    setOptions([...options, '']);
+  };
+
+  const removeOption = (index) => {
+    if (options.length > 1) {
+      const newOptions = options.filter((_, i) => i !== index);
+      setOptions(newOptions);
+    }
   };
 
   return (
@@ -28,7 +153,15 @@ const PlaceholderBuilderModal = ({ isOpen, onClose, onInsert }) => {
         <ModalCloseButton />
         <ModalBody>
           <VStack spacing={4} align="stretch">
-            <p>Placeholder configuration UI will be here.</p>
+            <FormControl>
+              <FormLabel>Placeholder Type</FormLabel>
+              <Select value={type} onChange={(e) => setType(e.target.value)}>
+                <option value="text">Text Input</option>
+                <option value="date">Date</option>
+                <option value="choice">Choice (Dropdown/Radio)</option>
+              </Select>
+            </FormControl>
+            {renderConfigUI()}
           </VStack>
         </ModalBody>
         <ModalFooter>


### PR DESCRIPTION
This commit represents Phase 2 of the 'Placeholder Builder' feature.

The `PlaceholderBuilderModal` component has been built out with a complete UI and internal logic for creating multiple types of placeholders.

Key changes:
- Added state management within the modal for type, name, options, etc.
- Implemented a type selector dropdown (Text, Date, Choice).
- Created dynamic forms that change based on the selected type.
- The "Choice" type form includes a dynamic list for managing options and a radio group to select the display style (Dropdown vs. Radio Buttons).
- Implemented the logic to generate the correct placeholder syntax for each type (e.g., `{{select:name:radio:option1}}`).