### PR TITLE
Feat: Implement nested placeholder evaluation

### DIFF
--- a/kolder-app/src/utils/placeholder-renderer.js
+++ b/kolder-app/src/utils/placeholder-renderer.js
@@ -1,6 +1,6 @@
 import { add, sub, format } from 'date-fns';
 
-// This new renderer will handle all placeholder types.
+// This new renderer will handle all placeholder types using a two-pass system.
 export const renderPlaceholders = (content, values) => {
   if (!content) {
     return '';
@@ -8,10 +8,29 @@ export const renderPlaceholders = (content, values) => {
 
   const placeholderRegex = /{{\s*([^}]+)\s*}}/g;
 
-  return content.replace(placeholderRegex, (match, expression) => {
+  // --- PASS 1: Resolve structural placeholders (e.g., select) ---
+  const pass1Content = content.replace(placeholderRegex, (match, expression) => {
     expression = expression.trim();
 
-    // 1. Handle 'date:' placeholders
+    if (expression.startsWith('select:')) {
+      const selectExpressionRegex = /^select:(\w+):/;
+      const parts = expression.match(selectExpressionRegex);
+      if (!parts) return match; // Invalid select expression
+
+      const variable = parts[1];
+      return values.choice?.[variable] || ''; // Return selected value or empty string
+    }
+
+    // If it's not a structural placeholder, leave it for the next pass
+    return match;
+  });
+
+
+  // --- PASS 2: Resolve value placeholders (e.g., text, date) ---
+  const pass2Content = pass1Content.replace(placeholderRegex, (match, expression) => {
+    expression = expression.trim();
+
+    // Handle 'date:' placeholders
     if (expression.startsWith('date:')) {
       const dateExpressionRegex = /^date:(\w+)(?:\s*([+-])\s*(\d+)\s*([dwmy]))?$/;
       const parts = expression.match(dateExpressionRegex);
@@ -43,17 +62,10 @@ export const renderPlaceholders = (content, values) => {
       }
     }
 
-    // 2. Handle 'select:' placeholders
-    if (expression.startsWith('select:')) {
-      const selectExpressionRegex = /^select:(\w+):/;
-      const parts = expression.match(selectExpressionRegex);
-      if (!parts) return match; // Invalid select expression
-
-      const variable = parts[1];
-      return values.choice?.[variable] || ''; // Return selected value or empty string
-    }
-
-    // 3. Handle simple text placeholders
+    // Handle simple text placeholders
+    // Note: 'select:' placeholders were already handled in pass 1, so we don't need to check for them here.
     return values.text?.[expression] || ''; // Return value or empty string
   });
+
+  return pass2Content;
 };


### PR DESCRIPTION
This commit enhances the placeholder rendering engine to support nested placeholders, where the output of one placeholder can contain another.

This was achieved by refactoring the `placeholder-renderer.js` utility to use a two-pass evaluation system:
1.  The first pass resolves "structural" placeholders, such as the `select` type. This turns a choice into part of the template.
2.  The second pass runs on the result of the first, resolving all remaining "value" placeholders like `date` and simple text inputs.

This two-pass approach provides the power of nested placeholders while preventing potential infinite loop issues that could arise from a fully recursive evaluation system.