### PR TITLE
Fix: Implement recursive parsing for nested placeholders

### DIFF
--- a/kolder-app/src/utils/placeholder-parser.js
+++ b/kolder-app/src/utils/placeholder-parser.js
@@ -1,42 +1,43 @@
-export const parsePlaceholders = (content) => {
-  const placeholders = {
-    text: new Set(),
-    date: new Set(),
-    choice: [],
-  };
+const _recursiveParse = (content, placeholders) => {
+    if (!content) {
+        return;
+    }
 
-  if (!content) {
-    return {
-        text: [],
-        date: [],
+    const placeholderRegex = /{{\s*([^}]+)\s*}}/g;
+    for (const match of content.matchAll(placeholderRegex)) {
+        const expression = match[1].trim();
+
+        if (expression.startsWith('date:')) {
+            const name = expression.substring(5).split(' ')[0];
+            if (name) placeholders.date.add(name);
+        } else if (expression.startsWith('select:')) {
+            const parts = expression.substring(7).split(':');
+            const [name, displayType, ...options] = parts;
+            if (name && displayType && options.length > 0) {
+                if (!placeholders.choice.some(c => c.name === name)) {
+                    placeholders.choice.push({ name, displayType, options });
+                    // Recursively parse the options themselves for more placeholders
+                    options.forEach(option => _recursiveParse(option, placeholders));
+                }
+            }
+        } else {
+            placeholders.text.add(expression);
+        }
+    }
+};
+
+export const parsePlaceholders = (content) => {
+    const placeholders = {
+        text: new Set(),
+        date: new Set(),
         choice: [],
     };
-  }
 
-  const placeholderRegex = /{{\s*([^}]+)\s*}}/g;
-  for (const match of content.matchAll(placeholderRegex)) {
-    const expression = match[1].trim();
+    _recursiveParse(content, placeholders);
 
-    if (expression.startsWith('date:')) {
-      const name = expression.substring(5).split(' ')[0];
-      if (name) placeholders.date.add(name);
-    } else if (expression.startsWith('select:')) {
-      const parts = expression.substring(7).split(':');
-      const [name, displayType, ...options] = parts;
-      if (name && displayType && options.length > 0) {
-        // Avoid adding duplicates if the same choice placeholder is in the text multiple times
-        if (!placeholders.choice.some(c => c.name === name)) {
-            placeholders.choice.push({ name, displayType, options });
-        }
-      }
-    } else {
-      placeholders.text.add(expression);
-    }
-  }
+    // Convert sets to arrays for easier use in components
+    placeholders.text = Array.from(placeholders.text);
+    placeholders.date = Array.from(placeholders.date);
 
-  // Convert sets to arrays for easier use in components
-  placeholders.text = Array.from(placeholders.text);
-  placeholders.date = Array.from(placeholders.date);
-
-  return placeholders;
+    return placeholders;
 };


### PR DESCRIPTION
This commit fixes a bug where placeholders nested inside the options of a 'select' placeholder were not being detected by the parser.

The `placeholder-parser.js` utility has been refactored to use a recursive approach. When the parser finds a `select` placeholder, it now recursively runs itself on the content of each option. This ensures that all placeholders are discovered, regardless of their nesting depth within other placeholders.

This change makes the placeholder system more powerful and aligns with the intuitive expectation that placeholders can be composed.