### PR TITLE
Fix: Correct CSS import location to prevent crash

### DIFF
--- a/kolder-app/src/App.jsx
+++ b/kolder-app/src/App.jsx
@@ -16,8 +16,6 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import debounce from 'lodash.debounce';
 import GridLayout from 'react-grid-layout';
-import 'react-grid-layout/css/styles.css';
-import 'react-resizable/css/styles.css';
 import CategoryTreeWidget from './components/widgets/CategoryTreeWidget';
 import SnippetListWidget from './components/widgets/SnippetListWidget';
 import CalendarWidget from './components/widgets/CalendarWidget';

--- a/kolder-app/src/main.jsx
+++ b/kolder-app/src/main.jsx
@@ -1,6 +1,8 @@
 import { StrictMode, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ChakraProvider, Spinner } from '@chakra-ui/react'
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
 import './index.css'
 import App from './App.jsx'
 import './i18n'; // Import the i18n configuration


### PR DESCRIPTION
This commit fixes a critical bug that caused the application to show a white screen on load after the introduction of the `react-grid-layout` library.

The library's required CSS files were being imported in `App.jsx`. For some bundlers and libraries, these global styles must be imported at the application's entry point to be loaded correctly.

The fix moves the two CSS imports (`react-grid-layout/css/styles.css` and `react-resizable/css/styles.css`) from `App.jsx` to `main.jsx`, ensuring they are loaded before the main application component renders. This resolves the loading crash.