### PR TITLE
Fix: Use fallback for clipboard copy in calendar modal

### DIFF
--- a/kolder-app/src/components/CalendarModal.jsx
+++ b/kolder-app/src/components/CalendarModal.jsx
@@ -48,8 +48,13 @@ const CalendarModal = ({ isOpen, onClose, settings }) => {
     if (event.nativeEvent.button === 2) {
       event.preventDefault();
       const formattedDate = format(day, 'dd.MM.yyyy');
+
+      // Use the new clipboard fallback
+      if (!navigator.clipboard) {
+        fallbackCopyTextToClipboard(formattedDate);
+        return;
+      }
       navigator.clipboard.writeText(formattedDate).then(() => {
-        console.log('Date copied to clipboard:', formattedDate);
         toast({
           title: 'Date Copied!',
           description: `${formattedDate} has been copied to your clipboard.`,
@@ -72,6 +77,52 @@ const CalendarModal = ({ isOpen, onClose, settings }) => {
       setDate(day);
     }
   };
+
+  const fallbackCopyTextToClipboard = (text) => {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+
+    // Avoid scrolling to bottom
+    textArea.style.top = '0';
+    textArea.style.left = '0';
+    textArea.style.position = 'fixed';
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+      const successful = document.execCommand('copy');
+      if (successful) {
+        toast({
+          title: 'Date Copied!',
+          description: `${text} has been copied to your clipboard.`,
+          status: 'success',
+          duration: 2000,
+          isClosable: true,
+        });
+      } else {
+        toast({
+          title: 'Error',
+          description: 'Could not copy date.',
+          status: 'error',
+          duration: 2000,
+          isClosable: true,
+        });
+      }
+    } catch (err) {
+      toast({
+        title: 'Error',
+        description: 'Could not copy date.',
+        status: 'error',
+        duration: 2000,
+        isClosable: true,
+      });
+      console.error('Fallback: Oops, unable to copy', err);
+    }
+
+    document.body.removeChild(textArea);
+  }
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered>


### PR DESCRIPTION
The calendar modal was not responding to right clicks on insecure origins (HTTP) because the `navigator.clipboard` API is not available in such contexts.

This commit fixes the issue by implementing a fallback mechanism using the older `document.execCommand('copy')` method. This ensures that the copy functionality works on both HTTP and HTTPS.

The `onClickDay` prop is used to handle both left and right clicks.
- A left click now correctly selects the date.
- A right click now copies the date to the clipboard using the new fallback method if `navigator.clipboard` is not available.