### PR TITLE
Fix: Use robust clipboard fallback for copy button

### DIFF
--- a/kolder-app/src/components/CalendarModal.jsx
+++ b/kolder-app/src/components/CalendarModal.jsx
@@ -25,13 +25,16 @@ const CalendarModal = ({ isOpen, onClose, settings }) => {
     const textArea = document.createElement('textarea');
     textArea.value = text;
 
-    // Avoid scrolling to bottom
-    textArea.style.top = '0';
-    textArea.style.left = '0';
-    textArea.style.position = 'fixed';
+    // Make the textarea non-editable and move it off-screen
+    textArea.setAttribute('readonly', '');
+    textArea.style.position = 'absolute';
+    textArea.style.left = '-9999px';
 
     document.body.appendChild(textArea);
-    textArea.focus();
+
+    // Save the current selection
+    const selected = document.getSelection().rangeCount > 0 ? document.getSelection().getRangeAt(0) : false;
+
     textArea.select();
 
     try {
@@ -65,6 +68,12 @@ const CalendarModal = ({ isOpen, onClose, settings }) => {
     }
 
     document.body.removeChild(textArea);
+
+    // Restore the original selection
+    if (selected) {
+      document.getSelection().removeAllRanges();
+      document.getSelection().addRange(selected);
+    }
   }, [toast]);
 
   const handleCopy = () => {


### PR DESCRIPTION
The "Copy Selected Date" button in the calendar modal was not correctly copying text on insecure origins (HTTP) because the `navigator.clipboard` API is unavailable. The initial fallback using `document.execCommand('copy')` was also unreliable, sometimes failing silently.

This commit improves the fallback mechanism to be more robust:
- A temporary textarea is created and moved off-screen.
- The user's current text selection is saved before the copy operation and restored afterward, preventing a poor user experience.
- The `readonly` attribute is set on the textarea to prevent focus-related issues.

This ensures that the copy functionality is reliable across different browser environments and contexts. The right-click copy feature has been removed in favor of this more explicit and robust button-based approach.