### PR TITLE
fix: Improve search relevance by removing strict threshold

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -327,10 +327,11 @@ app.get('/api/search', async (req, res) => {
                 hybridScore: cosineSimilarity(queryEmbedding, snippet.embedding) // Score is purely semantic
             }));
 
-            // Filter out snippets with low relevance and sort by score
+            // Sort by score and return the top N results. This is more robust
+            // than a fixed threshold, as it always returns the most likely candidates.
             const relevantResults = semanticResults
-                .filter(s => s.hybridScore > 0.35) // This threshold can be tuned
-                .sort((a, b) => b.hybridScore - a.hybridScore);
+                .sort((a, b) => b.hybridScore - a.hybridScore)
+                .slice(0, 10); // Return the top 10 results
 
             return res.json(relevantResults);
         }


### PR DESCRIPTION
This final commit addresses a critical flaw in the semantic search logic that caused relevant results to be filtered out incorrectly.

- **Problem:** The previous implementation used a fixed relevance threshold (`hybridScore > 0.35`) in the semantic search fallback. This was too strict and prevented thematically similar results (e.g., "heiss" for "Überhitzung") from appearing if their score was below this arbitrary value.

- **Solution:** The fixed threshold has been removed. The logic is updated to sort all semantic results by their score and return the top 10 candidates. This ensures that the most relevant results are always returned to the user, providing a much more robust and useful search experience.

This change completes the full implementation of the hybrid semantic search, including all necessary logic improvements and frontend integration.