### PR TITLE
feat: Add AI text generation for formalizing snippets

### DIFF
--- a/jules-scratch/verification/verify_llm_feature.py
+++ b/jules-scratch/verification/verify_llm_feature.py
@@ -1,0 +1,44 @@
+import re
+from playwright.sync_api import Page, expect
+
+def test_text_formalization(page: Page):
+    """
+    This test verifies that the text formalization feature works correctly.
+    1. It opens the snippet editor.
+    2. Enters a sentence in the informal "Du" form.
+    3. Clicks the "Umschreiben (Sie)" button.
+    4. Asserts that the text is correctly transformed into the formal "Sie" form.
+    5. Takes a screenshot of the result.
+    """
+    # 1. Arrange: Go to the application homepage.
+    page.goto("http://localhost:8448")
+
+    # 2. Act: Click the "New Snippet" button to open the editor.
+    # The button might take a moment to be ready after the initial data load.
+    new_snippet_button = page.locator("#snippet-list-new-snippet-button")
+    expect(new_snippet_button).to_be_visible(timeout=10000)
+    new_snippet_button.click()
+
+    # 3. Act: Enter informal text into the Quill editor.
+    # The editor is identified by its role 'textbox'.
+    editor_textbox = page.locator(".ql-editor")
+    expect(editor_textbox).to_be_visible()
+    informal_text = "Kannst du mir bitte helfen, das Problem zu lösen?"
+    editor_textbox.fill(informal_text)
+
+    # 4. Act: Click the "Umschreiben (Sie)" button.
+    formalize_button = page.get_by_role("button", name="Umschreiben (Sie)")
+    expect(formalize_button).to_be_enabled()
+    formalize_button.click()
+
+    # 5. Assert: Wait for the text to be updated to the formal version.
+    # We expect the text to contain "Können Sie" or a similar formal phrase.
+    # The AI's output can be variable, so we use a flexible regex.
+    # We also give it a generous timeout because the model on a Pi can be slow.
+    expect(editor_textbox).to_contain_text(re.compile(r"Können Sie|Würden Sie"), timeout=120000)
+
+    # Check that the original informal phrase is gone.
+    expect(editor_textbox).not_to_contain_text("Kannst du")
+
+    # 6. Screenshot: Capture the final result for visual verification.
+    page.screenshot(path="jules-scratch/verification/llm_formalize_feature.png")

--- a/server/generation-service.js
+++ b/server/generation-service.js
@@ -1,0 +1,58 @@
+/**
+ * A singleton class to manage the text generation pipeline.
+ * Ensures the T5 model is loaded only once.
+ */
+class GenerationService {
+    static instance = null;
+    static model = 'Xenova/t5-small';
+    static task = 'text2text-generation';
+
+    /**
+     * Retrieves the singleton instance of the generation pipeline.
+     * @returns {Promise<Function>} The text2text-generation pipeline function.
+     */
+    static async getInstance() {
+        if (this.instance === null) {
+            console.log('Initializing text generation model for the first time...');
+            const { pipeline } = await import('@xenova/transformers');
+            this.instance = await pipeline(this.task, this.model);
+            console.log('Text generation model loaded successfully.');
+        }
+        return this.instance;
+    }
+
+    /**
+     * Generates text based on a given input and a predefined task prefix.
+     * @param {string} inputText - The text to be transformed.
+     * @param {string} taskPrefix - The instruction for the model (e.g., "translate English to German: ").
+     * @returns {Promise<string|null>} The generated text, or null on error.
+     */
+    static async generate(inputText, taskPrefix) {
+        if (!inputText || !taskPrefix) {
+            return null;
+        }
+
+        const generator = await this.getInstance();
+        const fullPrompt = `${taskPrefix}${inputText}`;
+
+        const result = await generator(fullPrompt, {
+            max_new_tokens: 500, // Adjust as needed
+            temperature: 0.7,
+            repetition_penalty: 1.5,
+            no_repeat_ngram_size: 2,
+            early_stopping: true,
+        });
+
+        // The result is an array of objects, we need the generated_text from the first one.
+        if (result && result.length > 0 && result[0].generated_text) {
+            return result[0].generated_text;
+        }
+
+        return null;
+    }
+}
+
+// The model will be loaded on the first request now ("lazy loading").
+// GenerationService.getInstance();
+
+module.exports = GenerationService;

--- a/server/server.log
+++ b/server/server.log
@@ -1,6 +1,5 @@
-(node:7038) [MONGODB DRIVER] Warning: useNewUrlParser is a deprecated option: useNewUrlParser has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
+Initializing embedding model for the first time...
+(node:11049) [MONGODB DRIVER] Warning: useNewUrlParser is a deprecated option: useNewUrlParser has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:7038) [MONGODB DRIVER] Warning: useUnifiedTopology is a deprecated option: useUnifiedTopology has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
+(node:11049) [MONGODB DRIVER] Warning: useUnifiedTopology is a deprecated option: useUnifiedTopology has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
 Server is running on http://localhost:8448
-MongoDB connected successfully
-Default settings created.

--- a/server/server/package-lock.json
+++ b/server/server/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "server",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
This commit implements a new feature that allows users to automatically rephrase text within the snippet editor using a small, local language model.

Key features and changes:

- **Generation Service:** A new `server/generation-service.js` is created. It uses the `Xenova/t5-small` model to perform text-to-text generation tasks. The service is implemented as a singleton with lazy loading (the model is loaded on first use, not on server start) to conserve resources, which is critical for performance on a Raspberry Pi.

- **API Endpoint:** A new endpoint, `POST /api/text/generate`, is added to `server/server.js`. It accepts text and a task (e.g., 'formalize') and returns the AI-transformed text.

- **Frontend Integration:**
  - A new "Umschreiben (Sie)" button is added to the `SnippetEditor` component (`kolder-app/src/components/SnippetEditor.jsx`).
  - Clicking the button calls the new API with the editor's current text.
  - The editor's content is then replaced with the response from the AI.
  - A loading indicator provides user feedback during the generation process, which can take a few seconds.

- **Verification Issues:**
  - Despite extensive debugging of server startup and pathing issues, it was not possible to complete the Playwright-based frontend verification.
  - The test environment appears to crash silently when the text generation model is loaded, preventing the verification script from completing and capturing a screenshot.
  - The feature is fully implemented in the code and is expected to work on the target ARM64 hardware, but this could not be visually confirmed in the current environment.