### PR TITLE
feat: Extend AI actions with multiple text transformations

### DIFF
--- a/kolder-app/src/components/SnippetEditor.jsx
+++ b/kolder-app/src/components/SnippetEditor.jsx
@@ -16,7 +16,12 @@ import {
   Tag,
   TagLabel,
   TagCloseButton,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
 } from '@chakra-ui/react';
+import { ChevronDownIcon } from '@chakra-ui/icons';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import './quill.css';
@@ -57,25 +62,26 @@ const SnippetEditor = ({ onClose, onSave, snippet, settings }) => {
   }, [snippet]);
 
   /**
-   * Calls the backend to transform the text to the formal "Sie" form.
+   * Calls the backend to perform a text transformation task.
+   * @param {string} task - The specific task to perform (e.g., 'formalize', 'summarize').
    */
-  const handleFormalizeText = async () => {
+  const handleAITask = async (task) => {
     const editor = quillRef.current.getEditor();
-    const textToFormalize = editor.getText(); // Get plain text from Quill
-    if (!textToFormalize.trim()) return;
+    const textToTransform = editor.getText(); // Get plain text from Quill
+    if (!textToTransform.trim()) return;
 
     setIsGenerating(true);
     try {
       const response = await api.post('/text/generate', {
-        text: textToFormalize,
-        task: 'formalize',
+        text: textToTransform,
+        task: task, // Use the provided task parameter
       });
       if (response.data && response.data.generatedText) {
-        // Replace the entire content with the formalized text
+        // Replace the entire content with the transformed text
         setContent(response.data.generatedText);
       }
     } catch (error) {
-      console.error("Error generating formal text:", error);
+      console.error(`Error during AI task '${task}':`, error);
       // Optionally, show an error toast to the user
     } finally {
       setIsGenerating(false);
@@ -173,14 +179,23 @@ const SnippetEditor = ({ onClose, onSave, snippet, settings }) => {
               <Flex justify="space-between" align="center">
                   <FormLabel mb="0">Content</FormLabel>
                   <HStack>
-                    <Button
+                    <Menu>
+                      <MenuButton
+                        as={Button}
                         size="xs"
-                        onClick={handleFormalizeText}
+                        rightIcon={<ChevronDownIcon />}
                         isLoading={isGenerating}
-                        loadingText="Umschreiben..."
-                    >
-                        Umschreiben (Sie)
-                    </Button>
+                        loadingText="Arbeite..."
+                      >
+                        KI-Aktionen
+                      </MenuButton>
+                      <MenuList>
+                        <MenuItem onClick={() => handleAITask('formalize')}>Umschreiben (Sie)</MenuItem>
+                        <MenuItem onClick={() => handleAITask('correct-grammar')}>Grammatik korrigieren</MenuItem>
+                        <MenuItem onClick={() => handleAITask('summarize')}>Zusammenfassen</MenuItem>
+                        <MenuItem onClick={() => handleAITask('bullet-points')}>In Stichpunkte umwandeln</MenuItem>
+                      </MenuList>
+                    </Menu>
                     <Button size="xs" onClick={onBuilderOpen}>Insert Placeholder</Button>
                   </HStack>
               </Flex>

--- a/server/server.js
+++ b/server/server.js
@@ -545,6 +545,12 @@ app.post('/api/text/generate', async (req, res) => {
             case 'correct-grammar':
                 taskPrefix = 'Correct the grammar and spelling of the following text: ';
                 break;
+            case 'summarize':
+                taskPrefix = 'Summarize the following text concisely: ';
+                break;
+            case 'bullet-points':
+                taskPrefix = 'Convert the following text into a clear list of bullet points: ';
+                break;
             default:
                 return res.status(400).json({ error: 'Unsupported task.' });
         }


### PR DESCRIPTION
This commit significantly expands the AI capabilities within the snippet editor, evolving from a single "formalize" function to a versatile toolkit for text transformation.

Key changes:

- **Expanded Backend API:** The `/api/text/generate` endpoint in `server.js` now supports multiple tasks:
    - `formalize`: Rewrites text into the formal "Sie" form.
    - `correct-grammar`: Corrects grammar and spelling.
    - `summarize`: Creates a concise summary of the text.
    - `bullet-points`: Converts a block of text into a bulleted list.

- **Enhanced Frontend UI:**
    - The single "Umschreiben" button in `SnippetEditor.jsx` has been replaced with a "KI-Aktionen" dropdown menu (`Menu` from Chakra UI).
    - This menu provides users with clear access to all available text transformation options.

- **Refactored Frontend Logic:**
    - The `handleFormalizeText` function has been generalized to a more flexible `handleAITask(task)` function.
    - Each `MenuItem` in the new dropdown calls this function with the appropriate task string, making the code cleaner and more maintainable.

This implementation provides a much richer feature set, allowing users to improve their snippets in various ways directly within the editor, all powered by the local T5 model.