### PR TITLE
fix: Replace non-existent ChatIcon to resolve rendering crash

### DIFF
--- a/kolder-app/src/App.jsx
+++ b/kolder-app/src/App.jsx
@@ -11,7 +11,7 @@ import {
   IconButton,
   Image,
 } from '@chakra-ui/react';
-import { SettingsIcon, ViewIcon, AddIcon, CalendarIcon, ChatIcon } from '@chakra-ui/icons';
+import { SettingsIcon, ViewIcon, AddIcon, CalendarIcon, EditIcon } from '@chakra-ui/icons';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import CategoryTreeWidget from './components/widgets/CategoryTreeWidget';
@@ -444,7 +444,7 @@ function App() {
         />
         <IconButton
             onClick={onPromptManagerOpen}
-            icon={<ChatIcon />}
+            icon={<EditIcon />}
             aria-label="Manage Prompts"
             mr={2}
             bg={settings?.theme.accentColor}


### PR DESCRIPTION
This commit resolves a critical frontend bug that caused the entire application to show a blank white screen.

- **Problem:** The application was attempting to import and render a `ChatIcon` from `@chakra-ui/icons`. This icon does not exist in the installed version of the library, causing a JavaScript error that crashed the React rendering process.

- **Solution:** The non-existent `ChatIcon` has been replaced with the `EditIcon`, which is known to exist in the library. This resolves the rendering error and allows the application to load correctly.

This small but critical fix makes the entire custom prompt feature accessible and the application usable again.