### PR TITLE
fix: Add missing Heading import to resolve render crash

### DIFF
--- a/kolder-app/src/components/PromptManager.jsx
+++ b/kolder-app/src/components/PromptManager.jsx
@@ -18,7 +18,8 @@ import {
     Box,
     HStack,
     IconButton,
-    Text
+    Text,
+    Heading
 } from '@chakra-ui/react';
 import { EditIcon, DeleteIcon } from '@chakra-ui/icons';
 


### PR DESCRIPTION
This commit resolves a critical frontend bug that caused the entire application to show a blank white screen.

- **Problem:** The `PromptManager.jsx` component used the `Heading` component from Chakra UI without importing it. This resulted in a `ReferenceError: Heading is not defined` at runtime, which crashed the entire React application.

- **Solution:** The `Heading` component is now correctly imported from `@chakra-ui/react` within `PromptManager.jsx`.

This small but critical fix resolves the JavaScript error and allows the Prompt Manager and the rest of the application to render correctly.