### PR TITLE
feat: Integrate LanguageTool for German grammar checking

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@xenova/transformers": "^2.17.2",
+        "axios": "^1.12.2",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
         "express": "^4.19.2",
@@ -160,6 +161,23 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/b4a": {
       "version": "1.7.3",
@@ -446,6 +464,18 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -534,6 +564,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -627,6 +666,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -771,6 +825,42 @@
       "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -870,6 +960,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1418,6 +1523,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   "type": "commonjs",
   "dependencies": {
     "@xenova/transformers": "^2.17.2",
+    "axios": "^1.12.2",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.19.2",

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser');
 const cors = require('cors');
 const path = require('path');
 const mongoose = require('mongoose');
+const axios = require('axios');
 const { Category, Snippet, Settings, StartingSnippet } = require('./models');
 const EmbeddingService = require('./embedding-service');
 
@@ -257,6 +258,54 @@ app.delete('/api/snippets/:id', async (req, res) => {
         await Snippet.findByIdAndDelete(req.params.id);
         res.status(204).send();
     } catch (err) { res.status(500).json({ error: err.message }); }
+});
+
+
+// --- Grammar Check ---
+
+/**
+ * @route POST /api/check-grammar
+ * @description Checks a given text for grammar and style errors using LanguageTool.
+ * @param {object} req.body - The request body.
+ * @param {string} req.body.text - The text to be checked.
+ * @returns {object} 200 - The raw JSON response from the LanguageTool API.
+ * @returns {object} 500 - An error object if the check fails.
+ */
+app.post('/api/check-grammar', async (req, res) => {
+    try {
+        const { text } = req.body;
+        if (!text) {
+            return res.status(400).json({ error: 'Text to check is required.' });
+        }
+
+        const languageToolUrl = 'http://localhost:8081/v2/check';
+
+        // LanguageTool expects the data to be form-urlencoded
+        const params = new URLSearchParams();
+        params.append('text', text);
+        params.append('language', 'de-DE'); // Check for German
+
+        const response = await axios.post(languageToolUrl, params, {
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+        });
+
+        res.json(response.data);
+
+    } catch (error) {
+        // Log the detailed error for debugging
+        if (error.response) {
+            console.error('Error from LanguageTool API:', error.response.data);
+            res.status(error.response.status).json({ error: 'Error from LanguageTool API', details: error.response.data });
+        } else if (error.request) {
+            console.error('Error making request to LanguageTool:', error.request);
+            res.status(500).json({ error: 'Could not connect to LanguageTool service.' });
+        } else {
+            console.error('Error setting up grammar check request:', error.message);
+            res.status(500).json({ error: 'An internal server error occurred.' });
+        }
+    }
 });
 
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# This script starts the LanguageTool server in the background and then the Kolder app in the foreground.
+
+# Start LanguageTool Server
+# The '--allow-origin "*"' flag makes the API accessible from any origin.
+echo "Starting LanguageTool server on port 8081..."
+java -jar /app/languagetool/languagetool-server.jar --port 8081 --allow-origin '*' &
+
+# Give LanguageTool a moment to start up before the main application begins.
+sleep 5
+
+# Start Kolder application in the foreground
+echo "Starting Kolder server..."
+node server/server.js


### PR DESCRIPTION
This commit introduces a German grammar checking feature into the Snippet Editor by integrating LanguageTool directly into the application's Docker container.

Key changes:
- Modified the `Dockerfile` to install OpenJDK and download the LanguageTool server.
- Created a `start.sh` script to manage the concurrent startup of the LanguageTool server and the main Node.js application.
- Added a new backend API endpoint at `/api/check-grammar` which proxies requests from the frontend to the internal LanguageTool service.
- Updated the `SnippetEditor.jsx` frontend component to include a "Check Grammar" button.
- Implemented UI to display the grammar suggestions returned by LanguageTool directly below the content editor.

This implementation follows the user's request to keep the deployment simple by co-locating both services within the same container.