### PR TITLE
feat: Add local LanguageTool integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - "8448:8448"
     depends_on:
       - mongo
-      - languagetool
     environment:
       - MONGO_URI=mongodb://mongo:27017/kolderdb
       - PORT=8448
@@ -20,12 +19,6 @@ services:
       - "27017:27017"
     volumes:
       - mongo-data:/data/db
-
-  languagetool:
-    image: erikvl87/languagetool
-    ports:
-      - "8010:8010"
-    restart: always
 
 volumes:
   mongo-data:

--- a/server/models.js
+++ b/server/models.js
@@ -72,7 +72,7 @@ const settingsSchema = new mongoose.Schema({
         accentColor: { type: String, default: '#805AD5' },
     },
     languageToolEnabled: { type: Boolean, default: false },
-    languageToolApiUrl: { type: String, default: 'http://languagetool:8010/v2/check' },
+    languageToolApiUrl: { type: String, default: 'http://localhost:8010/v2/check' },
 });
 
 /**


### PR DESCRIPTION
This commit introduces optional, local LanguageTool support for grammar checking within the snippet editor. The feature is toggleable via the settings menu and allows for a custom API URL to be configured.

The LanguageTool service has been removed from the `docker-compose.yml` and is expected to be run separately by the user.

Key changes:
- Updates the `Settings` Mongoose model to include `languageToolEnabled` and `languageToolApiUrl`.
- Creates a new backend proxy endpoint in `server.js` to forward requests to the LanguageTool service, respecting the user's settings.
- Modifies `SettingsModal.jsx` to include a UI for enabling the feature and setting the API URL.
- Integrates the grammar checking functionality into `SnippetEditor.jsx`, adding a "Check Grammar" button and a component to display and apply suggestions.