### PR TITLE
feat: Add configurable language support for LanguageTool

### DIFF
--- a/kolder-app/src/components/SettingsModal.jsx
+++ b/kolder-app/src/components/SettingsModal.jsx
@@ -29,7 +29,7 @@ import axios from 'axios';
  * @returns {JSX.Element} The rendered component.
  */
 const SettingsModal = ({ isOpen, onClose, onSave, settings }) => {
-  const [currentSettings, setCurrentSettings] = useState({ title: '', icon: '', theme: { backgroundColor: '', contentBackgroundColor: '', textColor: '', accentColor: '' }, languageToolEnabled: false, languageToolApiUrl: '' });
+  const [currentSettings, setCurrentSettings] = useState({ title: '', icon: '', theme: { backgroundColor: '', contentBackgroundColor: '', textColor: '', accentColor: '' }, languageToolEnabled: false, languageToolApiUrl: '', languageToolLanguage: 'auto' });
 
   useEffect(() => {
     if (settings) {
@@ -39,6 +39,7 @@ const SettingsModal = ({ isOpen, onClose, onSave, settings }) => {
         theme: settings.theme || { backgroundColor: '', contentBackgroundColor: '', textColor: '', accentColor: '' },
         languageToolEnabled: settings.languageToolEnabled || false,
         languageToolApiUrl: settings.languageToolApiUrl || '',
+        languageToolLanguage: settings.languageToolLanguage || 'auto',
       });
     }
   }, [settings, isOpen]);
@@ -187,6 +188,16 @@ const SettingsModal = ({ isOpen, onClose, onSave, settings }) => {
                 value={currentSettings.languageToolApiUrl}
                 onChange={handleChange}
                 placeholder="e.g., http://localhost:8010/v2/check"
+                isDisabled={!currentSettings.languageToolEnabled}
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>LanguageTool Language</FormLabel>
+              <Input
+                name="languageToolLanguage"
+                value={currentSettings.languageToolLanguage}
+                onChange={handleChange}
+                placeholder="e.g., en-US, de-DE, auto"
                 isDisabled={!currentSettings.languageToolEnabled}
               />
             </FormControl>

--- a/server/models.js
+++ b/server/models.js
@@ -73,6 +73,7 @@ const settingsSchema = new mongoose.Schema({
     },
     languageToolEnabled: { type: Boolean, default: false },
     languageToolApiUrl: { type: String, default: 'http://localhost:8010/v2/check' },
+    languageToolLanguage: { type: String, default: 'auto' },
 });
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -594,9 +594,11 @@ app.post('/api/languagetool/check', async (req, res) => {
             return res.status(400).json({ error: 'LanguageTool is not enabled or configured.' });
         }
 
+        const language = settings.languageToolLanguage || 'auto';
+
         const response = await axios.post(
             settings.languageToolApiUrl,
-            `language=en-US&text=${encodeURIComponent(text)}`,
+            `language=${language}&text=${encodeURIComponent(text)}`,
             { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
         );
 


### PR DESCRIPTION
This commit enhances the LanguageTool integration by allowing the user to configure the grammar checking language. This addresses the user's request to support German grammar checking.

Key changes:
- Adds a `languageToolLanguage` field to the `settingsSchema` in `server/models.js`, with a default value of 'auto'.
- Updates the `/api/languagetool/check` endpoint in `server/server.js` to use the `languageToolLanguage` from the settings when making requests to the LanguageTool API.
- Modifies `SettingsModal.jsx` to include a new input field for the `languageToolLanguage`, allowing users to set the desired language code.