### PR TITLE
This commit introduces a new feature to the LanguageTool integration,…

### DIFF
--- a/kolder-app/src/components/SettingsModal.jsx
+++ b/kolder-app/src/components/SettingsModal.jsx
@@ -16,6 +16,7 @@ import {
   useToast,
   Switch,
   HStack,
+  Select,
 } from '@chakra-ui/react';
 import axios from 'axios';
 
@@ -29,7 +30,7 @@ import axios from 'axios';
  * @returns {JSX.Element} The rendered component.
  */
 const SettingsModal = ({ isOpen, onClose, onSave, settings }) => {
-  const [currentSettings, setCurrentSettings] = useState({ title: '', icon: '', theme: { backgroundColor: '', contentBackgroundColor: '', textColor: '', accentColor: '' }, languageToolEnabled: false, languageToolApiUrl: '', languageToolLanguage: 'auto' });
+  const [currentSettings, setCurrentSettings] = useState({ title: '', icon: '', theme: { backgroundColor: '', contentBackgroundColor: '', textColor: '', accentColor: '' }, languageToolEnabled: false, languageToolApiUrl: '', languageToolLanguage: 'auto', languageToolTone: 'default' });
 
   useEffect(() => {
     if (settings) {
@@ -40,6 +41,7 @@ const SettingsModal = ({ isOpen, onClose, onSave, settings }) => {
         languageToolEnabled: settings.languageToolEnabled || false,
         languageToolApiUrl: settings.languageToolApiUrl || '',
         languageToolLanguage: settings.languageToolLanguage || 'auto',
+        languageToolTone: settings.languageToolTone || 'default',
       });
     }
   }, [settings, isOpen]);
@@ -200,6 +202,19 @@ const SettingsModal = ({ isOpen, onClose, onSave, settings }) => {
                 placeholder="e.g., en-US, de-DE, auto"
                 isDisabled={!currentSettings.languageToolEnabled}
               />
+            </FormControl>
+            <FormControl>
+              <FormLabel>LanguageTool Tone (for German)</FormLabel>
+              <Select
+                name="languageToolTone"
+                value={currentSettings.languageToolTone}
+                onChange={handleChange}
+                isDisabled={!currentSettings.languageToolEnabled || !currentSettings.languageToolLanguage?.startsWith('de')}
+              >
+                <option value="default">Default</option>
+                <option value="formal">Formal (Sie)</option>
+                <option value="informal">Informal (Du)</option>
+              </Select>
             </FormControl>
             <Heading size="sm" mt={4} alignSelf="flex-start">Theme Colors</Heading>
              <FormControl>

--- a/server/models.js
+++ b/server/models.js
@@ -74,6 +74,7 @@ const settingsSchema = new mongoose.Schema({
     languageToolEnabled: { type: Boolean, default: false },
     languageToolApiUrl: { type: String, default: 'http://localhost:8010/v2/check' },
     languageToolLanguage: { type: String, default: 'auto' },
+    languageToolTone: { type: String, default: 'default' },
 });
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -596,9 +596,22 @@ app.post('/api/languagetool/check', async (req, res) => {
 
         const language = settings.languageToolLanguage || 'auto';
 
+        let postData = `language=${language}&text=${encodeURIComponent(text)}`;
+
+        // Add tone preference if language is German and a tone is selected
+        if (language.startsWith('de') && settings.languageToolTone && settings.languageToolTone !== 'default') {
+            // This is an undocumented feature found on the LanguageTool forum,
+            // using motherTongue to set the form of address (Anrede).
+            if (settings.languageToolTone === 'formal') {
+                postData += '&motherTongue=de-DE-x-formal-addr';
+            } else if (settings.languageToolTone === 'informal') {
+                postData += '&motherTongue=de-DE-x-informal-addr';
+            }
+        }
+
         const response = await axios.post(
             settings.languageToolApiUrl,
-            `language=${language}&text=${encodeURIComponent(text)}`,
+            postData,
             { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
         );
 


### PR DESCRIPTION
… allowing users to select a formal ('Sie') or informal ('Du') tone for German language checks.

Key changes:
- Added a `languageToolTone` field to the `Settings` model in `server/models.js`.
- Updated the LanguageTool proxy in `server/server.js` to use the `motherTongue` parameter to pass the selected tone to the LanguageTool API.
- Added a dropdown menu in the `SettingsModal.jsx` component to allow users to select their preferred tone. The dropdown is only enabled when the selected language is German.