### PR TITLE
fix: Handle Unicode characters in placeholder names

### DIFF
--- a/kolder-app-dev.log
+++ b/kolder-app-dev.log
@@ -1,5 +1,0 @@
-
-> kolder-app@0.0.0 dev
-> vite
-
-sh: 1: vite: not found

--- a/kolder-app/src/utils/placeholder-parser.js
+++ b/kolder-app/src/utils/placeholder-parser.js
@@ -17,7 +17,8 @@ const _recursiveParse = (content) => {
     for (const expression of expressions) {
         let placeholder;
         if (expression.startsWith('date:')) {
-            const nameMatch = expression.substring(5).match(/^(\w+)/);
+            // Use a regex that supports Unicode characters for the placeholder name.
+            const nameMatch = expression.substring(5).match(/^([\p{L}\p{N}_]+)/u);
             if (nameMatch) {
                 const name = nameMatch[1];
                 placeholder = { type: 'date', name };
@@ -25,6 +26,7 @@ const _recursiveParse = (content) => {
         } else if (expression.startsWith('select:')) {
             const parts = expression.substring(7).split(':');
             const [name, displayType, ...options] = parts;
+            // The name here is just split, so it should handle Unicode correctly.
             if (name && displayType && options.length > 0) {
                 const nestedPlaceholders = options.flatMap(option => _recursiveParse(option));
                 placeholder = { type: 'choice', name, displayType, options, children: nestedPlaceholders };
@@ -61,7 +63,6 @@ export const parsePlaceholders = (content) => {
             } else if (node.type === 'date') {
                 placeholders.date.add(node.name);
             } else if (node.type === 'choice') {
-                // Avoid adding duplicates
                 if (!placeholders.choice.some(c => c.name === node.name)) {
                     placeholders.choice.push({
                         name: node.name,

--- a/kolder-app/src/utils/placeholder-renderer.js
+++ b/kolder-app/src/utils/placeholder-renderer.js
@@ -35,7 +35,8 @@ const evaluateExpression = (expression, values) => {
     expression = expression.trim();
 
     if (expression.startsWith('select:')) {
-        const selectExpressionRegex = /^select:(\w+):/;
+        // Use a regex that supports Unicode characters for the placeholder name.
+        const selectExpressionRegex = /^select:([\p{L}\p{N}_]+):/u;
         const parts = expression.match(selectExpressionRegex);
         if (!parts) return `{{${expression}}}`;
         const variable = parts[1];
@@ -43,7 +44,8 @@ const evaluateExpression = (expression, values) => {
     }
 
     if (expression.startsWith('date:')) {
-        const dateExpressionRegex = /^date:(\w+)((?:[+-]\d+[dwmy])+)?$/;
+        // Use a regex that supports Unicode characters for the placeholder name.
+        const dateExpressionRegex = /^date:([\p{L}\p{N}_]+)((?:[+-]\d+[dwmy])+)?$/u;
         const parts = expression.match(dateExpressionRegex);
         if (!parts) return `{{${expression}}}`;
 
@@ -77,6 +79,8 @@ const evaluateExpression = (expression, values) => {
         }
     }
 
+    // For text placeholders, the name is the entire expression.
+    // It should also correctly handle Unicode characters.
     return values.text?.[expression] || '';
 };
 


### PR DESCRIPTION
- Update the placeholder parser and renderer to correctly handle Unicode characters (e.g., German umlauts) in placeholder names. This fixes a bug where names like "Kündigungsdatum" were being truncated.